### PR TITLE
Add basic iteration entry module (#30)

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -9,11 +9,13 @@ app_server <- function(input, output, session) {
   # UI for data entry endpoints
   # Collect entered data
   data_entered_probs <- mod_data_entry_server("data_entry_1")
+  data_entered_iters <- mod_iterations_server("iterations_1")
+
 
   # Pass collected data to stats calculations
   mod_stats_calculations_server("stats_calculations_1",
                                 probability_data = data_entered_probs,
-                                iterations = NULL,
+                                iterations = data_entered_iters,
                                 sample_size = NULL)
 
   # PLACEHOLDER: pass results to output options such as .Rdata/.csv

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -13,7 +13,19 @@ app_ui <- function(request) {
       # h1("SyntheticParameters")
       title = "Synthetic Paremeters",
 
-      mod_data_entry_ui("data_entry_1"),
+
+      tabPanel(title = "Data Input",
+               fluidPage(
+                 sidebarLayout(
+                   sidebarPanel(
+                     # something here? data upload option?
+                     mod_iterations_ui("iterations_1")
+                   ),
+                   mainPanel(
+                     mod_data_entry_ui("data_entry_1")
+                   )
+                 )
+               )),
       mod_stats_calculations_ui("stats_calculations_1")
 
 

--- a/R/mod_data_entry.R
+++ b/R/mod_data_entry.R
@@ -10,17 +10,9 @@
 mod_data_entry_ui <- function(id){
   ns <- NS(id)
 
-    tabPanel(title = "Data Input",
-             fluidPage(
-               sidebarLayout(
-                 sidebarPanel(
-                   # something here? data upload option?
-                 ),
-                 mainPanel(
-                   rhandsontable::rHandsontableOutput(ns("hottable"))
-                 )
-               )
-             ))
+  tagList(
+   rhandsontable::rHandsontableOutput(ns("hottable"))
+   )
 
 }
 

--- a/R/mod_iterations.R
+++ b/R/mod_iterations.R
@@ -1,0 +1,37 @@
+#' iterations UI Function
+#'
+#' @description A shiny Module.
+#'
+#' @param id,input,output,session Internal parameters for {shiny}.
+#'
+#' @noRd
+#'
+#' @importFrom shiny NS tagList
+mod_iterations_ui <- function(id){
+  ns <- NS(id)
+  tagList(
+    shiny::numericInput(ns("iterations"), "Number of Iterations", 1, min = 1, max = Inf),
+    shiny::textOutput(ns("iter_out"))
+  )
+}
+
+#' iterations Server Functions
+#'
+#' @noRd
+mod_iterations_server <- function(id){
+  moduleServer( id, function(input, output, session){
+    ns <- session$ns
+
+
+    iterations <- reactive({input$iterations})
+
+    return(iterations)
+
+  })
+}
+
+## To be copied in the UI
+# mod_iterations_ui("iterations_1")
+
+## To be copied in the server
+# mod_iterations_server("iterations_1")

--- a/R/mod_stats_calculations.R
+++ b/R/mod_stats_calculations.R
@@ -27,17 +27,25 @@ mod_stats_calculations_server <- function(id, probability_data, iterations, samp
     parameters <- reactive({
         list(
         null_probs = dplyr::pull(probability_data(), "Null Group Probabilities"),
-        int_probs = dplyr::pull(probability_data(), "Intervention Group Probs.")
-        #, iterations = iterations()
+        int_probs = dplyr::pull(probability_data(), "Intervention Group Probs."),
+        iterations = iterations()
         #, sample_size = sample_size()
         )
       })
 
-    # usage example: paraemeters()$null_probs
+
+    # usage example: parameters()$null_probs
     # NOTE: the whole list is reactive, and need to subset elements after
     # calling reactivity
 
-    output$testing <- shiny::renderText({ c(parameters()$null_probs, parameters()$int_probs) })
+    output$testing <- shiny::renderText({
+      c(
+        # parameters()$null_probs,
+        # parameters()$int_probs,
+        parameters()$iterations
+        )
+      })
+
 
   })
 }


### PR DESCRIPTION
* Create module template for iterations input

* Relocate data entry UI components

The fluidPage() code for entering parameters now lives directly in the app_ui() rather than behind the data entry module. This makes it easier to insert other modules into the page such as iterations.

* Create functioning module for entering iterations

Iterations can be entered in a side panel on the data entry page, and are currently printed in the testing portion of the stats calculations server (just to demonstrate successful passing of values).

Closes #28 