### PR TITLE
Change triggers for running R CMD checks

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master, development]
+    branches: [main, master]
   # pull_request:
   #   branches: [main, master]
   workflow_dispatch:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,10 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
+    branches: [main, master, development]
+  # pull_request:
+  #   branches: [main, master]
+  workflow_dispatch:
 
 name: R-CMD-check
 


### PR DESCRIPTION
Run checks only on pushes (i.e. when a branch is merged--this necessarily creates a push) to the master and development branches. Enable workflow dispatching for any branch.