### PR TITLE
Ignore R/_disable_autoload.R when building pkg

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -19,3 +19,4 @@ $run_dev.*
 ^pkgdown$
 ^.covrignore$
 ^codecov\.yml$
+^R/_disable_autoload\.R$


### PR DESCRIPTION
The `R/_disable_autoload.R` script is included to prevent some Shiny behavior on deployment to ShinyApps.io. However, this file should not be included when building the R package itself.

Unclear whether including this in the .Rbuildignore will affect the ShinyApps.io deployment or not 🤷 