### PR TITLE
Move up minimum R requirement to match {rms}

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,5 +42,5 @@ Suggests:
     writexl
 Config/testthat/edition: 3
 Depends: 
-    R (>= 3.5.10)
+    R (>= 4.4.0)
 VignetteBuilder: knitr


### PR DESCRIPTION
The {rms} package recently introduced a minimum R requirement of using >=v4.4.0 which means this package is now also necessarily dependent on >=v4.4.0