### PR TITLE
Fix error when only 1 test is selected

### DIFF
--- a/R/ordinal_tests.R
+++ b/R/ordinal_tests.R
@@ -15,7 +15,7 @@
 #' @param included a character vector of the tests to be included. Default is "all"
 #' @param ... Placeholder for additional arguments to functions
 #'
-#' @return A named vector of probabilities for each test
+#' @return A named matrix of probabilities for each test
 #'
 #' The function is designed to run all 6 tests by default. If you want to run only a subset of the tests, you can specify them in the `included` argument. The following values are possible:
 #'
@@ -145,15 +145,17 @@ ordinal_tests <- function(x, y, included = "all", ...) {
     coin_indep_test <- NULL
   }
 
+  output <- matrix(c(
+    Wilcoxon = wilcoxon,
+    Fisher = fisher,
+    "Chi Squared\n(No Correction)" = chi_sq_no_correction,
+    "Chi Squared\n(Correction)" = chi_sq_correction,
+    "Prop. Odds" = prop_odds,
+    "Coin Indep. Test" = coin_indep_test
+  ),
+  ncol = length(included))
 
-  return(
-    c(
-      Wilcoxon = wilcoxon,
-      Fisher = fisher,
-      "Chi Squared\n(No Correction)" = chi_sq_no_correction,
-      "Chi Squared\n(Correction)" = chi_sq_correction,
-      "Prop. Odds" = prop_odds,
-      "Coin Indep. Test" = coin_indep_test
-    )
-  )
+  colnames(output) <- included
+
+  return(output)
 }

--- a/ordinalsimr.Rproj
+++ b/ordinalsimr.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 4940e906-b1ed-49e3-af8e-92d67615f379
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/tests/testthat/test-ordinal_tests.R
+++ b/tests/testthat/test-ordinal_tests.R
@@ -30,9 +30,9 @@ test_that("ordinal_tests returns a vector of length 3", {
 
 test_that("ordinal_tests names the vector correctly", {
   suppressWarnings(
-    expect_named(
-      ordinal_tests(groups[["x"]], groups[["y"]]),
-      c("Wilcoxon", "Fisher", "Chi Squared\n(No Correction)", "Chi Squared\n(Correction)", "Prop. Odds", "Coin Indep. Test")
+    expect_equal(
+      colnames(ordinal_tests(groups[["x"]], groups[["y"]])),
+      c("Wilcoxon", "Fisher", "Chi Squared (No Correction)", "Chi Squared (Correction)", "Prop. Odds", "Coin Indep. Test")
     )
   )
 })
@@ -59,8 +59,8 @@ test_that("ordinal_tests functions correctly on a subset of tests", {
       included = c("Wilcoxon", "Fisher")
     )
   )
-  expect_vector(subset_results)
-  expect_named(subset_results)
+  expect_true(is.matrix(subset_results))
+  expect_equal(colnames(subset_results), c("Wilcoxon", "Fisher"))
   expect_equal(as.vector(subset_results)[1],
     c(0.002205771),
     tolerance = 0.0000001

--- a/tests/testthat/test-run_simulations.R
+++ b/tests/testthat/test-run_simulations.R
@@ -60,8 +60,8 @@ test_that("run_simulations returns data frames with the correct column names", {
   expect_named(
     run_sims_output[["sample_size_40"]],
     c(
-      "Wilcoxon", "Fisher", "Chi Squared\n(No Correction)",
-      "Chi Squared\n(Correction)", "Prop. Odds", "Coin Indep. Test",
+      "Wilcoxon", "Fisher", "Chi Squared (No Correction)",
+      "Chi Squared (Correction)", "Prop. Odds", "Coin Indep. Test",
       "run", "y", "x", "n_null", "n_intervene", "sample_size", "K"
     )
   )


### PR DESCRIPTION
Return named matrix from ordinal_tests

* Fix downstream code in run_simulations
* Update tests for names

Closes #164 