### PR TITLE
Add a confidence interval option to the power plot

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -25,6 +25,7 @@ app_server <- function(input, output, session) {
   run_simulation_button <- mod_start_simulation_server("start_simulation_1")
   t1_error_toggle <- mod_type_one_error_server("type_one_error_1")
   kill_button <- mod_kill_simulations_server("kill_simulations_1")
+  confidence_interval_toggle <- mod_distributions_page_server("distributions_page_1")
 
   mod_progress_modal_server("progress_modal_1", open_modal_from_sim_start = run_simulation_button)
 
@@ -64,7 +65,8 @@ app_server <- function(input, output, session) {
   distributions_power_error <- mod_plot_distributions_server("plot_distributions_1",
     p_value_table = results_output,
     n = data_entered_sample_size,
-    reactive_bg_process = reactive_bg_process
+    reactive_bg_process = reactive_bg_process,
+    ci_band = confidence_interval_toggle
   )
 
   # format the data and plots into a list, and make this object available for

--- a/R/mod_distributions_page.R
+++ b/R/mod_distributions_page.R
@@ -45,7 +45,7 @@ mod_distributions_page_ui <- function(id) {
             "))
           ),
           div(class = "plot-container",
-              div(class = "overlay-checkbox", checkboxInput(ns("show_confidence_interval"), "Show CI %", value = TRUE)),
+              div(class = "overlay-checkbox", checkboxInput(ns("show_confidence_interval"), "Show CI", value = TRUE)),
               mod_plot_distributions_ui("plot_distributions_1")[["output_plots"]][["power_plot"]]
           ),
         ),

--- a/R/mod_distributions_page.R
+++ b/R/mod_distributions_page.R
@@ -28,7 +28,26 @@ mod_distributions_page_ui <- function(id) {
         ),
         nav_panel(
           title = "Power",
-          mod_plot_distributions_ui("plot_distributions_1")[["output_plots"]][["power_plot"]]
+          tags$head(
+            tags$style(HTML("
+              .plot-container {
+                position: relative;
+              }
+              .overlay-checkbox {
+                position: absolute;
+                top: 0px;
+                right: -150px;
+                z-index: 10;
+                background: rgba(255, 255, 255, 0.8);
+                padding: 5px 10px;
+                border-radius: 4px;
+              }
+            "))
+          ),
+          div(class = "plot-container",
+              div(class = "overlay-checkbox", checkboxInput(ns("show_confidence_interval"), "Show CI %", value = TRUE)),
+              mod_plot_distributions_ui("plot_distributions_1")[["output_plots"]][["power_plot"]]
+          ),
         ),
         nav_panel(
           title = "p-values",
@@ -46,6 +65,9 @@ mod_distributions_page_ui <- function(id) {
 mod_distributions_page_server <- function(id) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+
+    return(reactive({input$show_confidence_interval}))
+
   })
 }
 

--- a/R/mod_plot_distributions.R
+++ b/R/mod_plot_distributions.R
@@ -80,7 +80,7 @@ mod_plot_distributions_ui <- function(id) {
 #' plot_distributions Server Functions
 #'
 #' @noRd
-mod_plot_distributions_server <- function(id, p_value_table, n, reactive_bg_process) {
+mod_plot_distributions_server <- function(id, p_value_table, n, reactive_bg_process, ci_band) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
@@ -158,7 +158,7 @@ mod_plot_distributions_server <- function(id, p_value_table, n, reactive_bg_proc
     output$power_plot <- renderPlot({
       validate(need(nrow(p_value_reactive_table()) > 0 , "Calculation ongoing"))
       distribution_statistics() %>%
-        plot_power(power_threshold = input$power_value)
+        plot_power(power_threshold = input$power_value, ci_band = ci_band())
     })
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -207,7 +207,7 @@ plot_distribution_results <- function(df, alpha = 0.05, outlier_removal = 0.10) 
 #' @return ggplot object
 #' @export
 #'
-plot_power <- function(df, power_threshold = 0.80) {
+plot_power <- function(df, power_threshold = 0.80, ci_band = TRUE) {
   levels <- df %>%
     group_by(.data[["test"]]) %>%
     summarize(
@@ -215,6 +215,13 @@ plot_power <- function(df, power_threshold = 0.80) {
     ) %>%
     arrange(desc(.data[["mean"]])) %>%
     pull(.data[["test"]])
+
+  ribbon <- if (ci_band) {
+    geom_ribbon(
+      aes(ymin = lower_power_bound, ymax = upper_power_bound),
+      alpha = 0.05, color = NA
+    )
+  } else {NULL}
 
   df %>%
     mutate(test = factor(.data[["test"]], levels = levels)) %>%
@@ -225,6 +232,7 @@ plot_power <- function(df, power_threshold = 0.80) {
     )) +
     geom_line(linewidth = 2) +
     geom_hline(yintercept = power_threshold, linetype = "dashed", linewidth = 1.5) +
+    ribbon +
     expand_limits(y = c(0, 1)) +
     ggtitle("Estimated Power") +
     labs(x = "Sample Size", y = "Power (1-\U03B2)", color = "Statistical Test") +


### PR DESCRIPTION
Default is to show the confidence interval around power values, but this can be toggled off